### PR TITLE
Add initial 5e to Daggerheart stat block converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+*.swp
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# 5e-to-Daggerheart-Stat-block-converter
+# 5e to Daggerheart Stat Block Converter
+
+This repository contains a simple Python utility for translating a subset of
+Dungeons & Dragons 5th Edition creature statistics into an equivalent
+representation for the Daggerheart role‑playing game.
+
+The mapping implemented here is intentionally lightweight and is intended as a
+starting point for further refinement.  Not all concepts from either system are
+covered.
+
+## Usage
+
+```
+python converter.py path/to/5e_stat_block.json -o daggerheart.json
+```
+
+The input file must be a JSON object with the following keys:
+
+- `name`
+- `strength`
+- `dexterity`
+- `constitution`
+- `intelligence`
+- `wisdom`
+- `charisma`
+- `armor_class`
+- `hit_points`
+- `challenge_rating`
+
+The resulting file will contain a Daggerheart stat block with the fields:
+`name`, `level`, `body`, `agility`, `mind`, `spirit`, `defense`, and `health`.
+
+## Development
+
+Run the tests with:
+
+```
+pytest
+```

--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,149 @@
+"""5e to Daggerheart creature stat block converter.
+
+This module provides utilities to convert a subset of Dungeons & Dragons
+5th Edition creature statistics into an equivalent representation for the
+Daggerheart role‑playing game.
+
+The conversion implemented here is intentionally simplistic.  Daggerheart
+is a different system and there is no one‑to‑one mapping for all concepts.
+However, the mapping used by this tool can serve as a starting point for
+further refinement.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class FiveEStatBlock:
+    """Subset of fields from a 5e creature stat block."""
+
+    name: str
+    strength: int
+    dexterity: int
+    constitution: int
+    intelligence: int
+    wisdom: int
+    charisma: int
+    armor_class: int
+    hit_points: int
+    challenge_rating: float
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FiveEStatBlock":
+        required = [
+            "name",
+            "strength",
+            "dexterity",
+            "constitution",
+            "intelligence",
+            "wisdom",
+            "charisma",
+            "armor_class",
+            "hit_points",
+            "challenge_rating",
+        ]
+        missing = [key for key in required if key not in data]
+        if missing:
+            raise KeyError(f"Missing keys for FiveEStatBlock: {', '.join(missing)}")
+        return cls(**{key: data[key] for key in required})
+
+
+@dataclass
+class DaggerheartStatBlock:
+    """Simple Daggerheart representation produced by the converter."""
+
+    name: str
+    level: int
+    body: int
+    agility: int
+    mind: int
+    spirit: int
+    defense: int
+    health: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "level": self.level,
+            "body": self.body,
+            "agility": self.agility,
+            "mind": self.mind,
+            "spirit": self.spirit,
+            "defense": self.defense,
+            "health": self.health,
+        }
+
+
+def ability_average(*scores: int) -> int:
+    """Return the rounded average of the provided ability scores."""
+
+    return int(round(sum(scores) / len(scores)))
+
+
+def challenge_to_level(cr: float) -> int:
+    """Convert a 5e challenge rating to an approximate Daggerheart level."""
+
+    import math
+
+    if cr <= 0:
+        return 0
+    # Map CR directly to level, always rounding up and capping at 20.
+    return int(min(math.ceil(cr), 20))
+
+
+def convert_5e_to_daggerheart(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a 5e stat block dictionary to a Daggerheart representation.
+
+    Parameters
+    ----------
+    data:
+        Mapping containing at least the keys required by :class:`FiveEStatBlock`.
+
+    Returns
+    -------
+    dict
+        Dictionary representing the Daggerheart stat block.
+    """
+
+    five_e = FiveEStatBlock.from_dict(data)
+    daggerheart = DaggerheartStatBlock(
+        name=five_e.name,
+        level=challenge_to_level(five_e.challenge_rating),
+        body=ability_average(five_e.strength, five_e.constitution),
+        agility=five_e.dexterity,
+        mind=ability_average(five_e.intelligence, five_e.wisdom),
+        spirit=five_e.charisma,
+        defense=five_e.armor_class,
+        health=five_e.hit_points,
+    )
+    return daggerheart.to_dict()
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+    import sys
+    from pathlib import Path
+
+    parser = argparse.ArgumentParser(
+        description="Convert a 5e stat block JSON file to Daggerheart format",
+    )
+    parser.add_argument("input", type=Path, help="Path to 5e stat block JSON file")
+    parser.add_argument(
+        "-o", "--output", type=Path, help="Output path for Daggerheart JSON"
+    )
+    args = parser.parse_args()
+
+    with args.input.open() as fp:
+        data = json.load(fp)
+
+    result = convert_5e_to_daggerheart(data)
+
+    if args.output:
+        with args.output.open("w") as fp:
+            json.dump(result, fp, indent=2)
+    else:
+        json.dump(result, sys.stdout, indent=2)
+        print()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import converter
+
+
+def test_basic_conversion():
+    data = {
+        "name": "Orc",
+        "strength": 16,
+        "dexterity": 12,
+        "constitution": 16,
+        "intelligence": 7,
+        "wisdom": 11,
+        "charisma": 10,
+        "armor_class": 13,
+        "hit_points": 15,
+        "challenge_rating": 0.5,
+    }
+    expected = {
+        "name": "Orc",
+        "level": 1,  # ceil(0.5)
+        "body": 16,  # avg(16,16)
+        "agility": 12,
+        "mind": 9,  # avg(7,11)
+        "spirit": 10,
+        "defense": 13,
+        "health": 15,
+    }
+    assert converter.convert_5e_to_daggerheart(data) == expected


### PR DESCRIPTION
## Summary
- Implement basic converter translating core 5e creature stats into simplified Daggerheart format
- Document usage and expected JSON structure
- Add unit test exercising example conversion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa19979948329af818586afbdbe4b